### PR TITLE
use continue, not return, to avoid duplicate registrations

### DIFF
--- a/samsara/inputs/GenericInput.js
+++ b/samsara/inputs/GenericInput.js
@@ -77,7 +77,7 @@ define(function(require, exports, module) {
     GenericInput.register = function register(inputObject) {
         for (var key in inputObject){
             if (registry[key]){
-                if (registry[key] === inputObject[key]) return; // redundant registration
+                if (registry[key] === inputObject[key]) continue; // redundant registration
                 else throw new Error('this key is registered to a different input class');
             }
             else registry[key] = inputObject[key];


### PR DESCRIPTION
Investigating the bug I found with #19:

> the SideMenu demo no longer registers the drag gesture. No error is reported. Possibly an order-of-execution thing – will keep prodding it and see if I can work out what happened

Turns out that the same bug presents if you use the current UMD build. It happens because `Scrollview` calls `GenericInput.register` as soon as it executes, and `GenericInput.register` bails if it sees a duplicate registration. This PR fixes it. I've applied the same fix to #19.