### PR TITLE
Correct 'itemsByRow' to be 'itemsPerRow' in GridLayout docs

### DIFF
--- a/samsara/layouts/GridLayout.js
+++ b/samsara/layouts/GridLayout.js
@@ -22,7 +22,7 @@ define(function(require, exports, module) {
      *  @constructor
      *  @extends Core.View
      *  @param [options] {Object}                           Options
-     *  @param options.itemsByRow {Array|Object}            Number of items per row, or an object of {width : itemsByRow} pairs
+     *  @param options.itemsPerRow {Array|Object}            Number of items per row, or an object of {width : itemsPerRow} pairs
      *  @param [options.gutter=0] {Transitionable|Number}   Gap space between successive items
      */
     var GridLayout = View.extend({


### PR DESCRIPTION
As per previous pull request but without generated docs and `/dist`.