### PR TITLE
Added "don't update dist and docs in pull request"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ If you're brave enough to contribute still, please make sure to
 
 * Use the same coding style as the rest of the codebase.
 
+* Only change the source files necessary. We'll build the distribution bundles, documentation, etc. upon a new release.
+
 * Make your pull request to the `master` branch. So please
 rebase your pull request on `master` if `master` has changed. 
 


### PR DESCRIPTION
Sharing feedback from @dmvaldman: Typically when contributing to an open-source project, the contributor only changes the source files as necessary, and it is up to the maintainer to build the bundles/documentation/etc upon a new release. This avoids a lot of merge conflicts, properly distributes credit, and is much better for testing and releasing.