### PR TITLE
Adding Samsara to bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "samsarajs",
+  "description": "Reactive layout for user interfaces",
+  "main": "dist/samsara.js",
+  "authors": [
+    "David Valdman <dmvaldman@gmail.com>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "UI",
+    "streams",
+    "FRP",
+    "reactive",
+    "layout",
+    "samsara"
+  ],
+  "homepage": "https://github.com/dmvaldman/samsara.git",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I almost have a working Yeoman generator that kicks out a project of the cube example along with grunt to do operations like locally serving the project and minifying for distribution. Setting up the dependencies for the output project would be easier if Samsara was a bower package. All that is needed is the included `bower.json` file to be in the repo, and to then run the `bower register` command.

Something like:
`bower register samsarajs https://github.com/dmvaldman/samsara.git`

The generator is here: https://github.com/richardkopelow/generator-samsara